### PR TITLE
Updated index.js with support for top.gg autoposting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const client = new Client({
 });
 const { token } = require("../config.json");
 const Paginator = require("./paginator");
+const { AutoPoster } = require('topgg-autoposter')
 
 const snipes = {};
 const editSnipes = {};
@@ -139,5 +140,10 @@ client.on("interactionCreate", async (interaction) => {
 		);
 	}
 });
+const ap = AutoPoster('Your Top.gg Token', client)
+
+ap.on('posted', () => {
+  console.log('Posted stats to Top.gg!')
+})
 
 client.login(token);


### PR DESCRIPTION
If you decide to host your wonderful snipe bot on top.gg, it can now post statistics like server count to the bot page. 
But before you do this, please install this library using: npm i topgg-autoposter
In the field for 'your top.gg token', you need to enter the token from your bot dashboard's edit page -> webhooks. This is not the same as your Discord bot token.